### PR TITLE
Stylesheet updates for MonoBook and Vector

### DIFF
--- a/LocalSettings.archlinux.org.php
+++ b/LocalSettings.archlinux.org.php
@@ -55,9 +55,9 @@ $wgScriptExtension  = ".php";
 ## The relative URL path to the skins directory
 $wgStylePath        = "$wgScriptPath/skins";
 
-## The relative URL path to the logo.  Make sure you change this from the default,
-## or else you'll overwrite your logo when you upgrade!
-$wgLogo             = "$wgStylePath/ArchLinux/archlogo.png";
+## The relative URL path to the logo.
+## (commented out, it is not shown anywhere)
+#$wgLogo             = "$wgScriptPath/extensions/ArchLinux/modules/archnavbar/archlogo.svg";
 
 ## For attaching licensing metadata to pages, and displaying an
 ## appropriate copyright notice / icon. GNU Free Documentation

--- a/extensions/ArchLinux/extension.json
+++ b/extensions/ArchLinux/extension.json
@@ -26,7 +26,8 @@
       ],
       "styles": [
         "archnavbar/archnavbar.less",
-        "archnavbar/responsive.less"
+        "archnavbar/responsive.less",
+        "arch_common.less"
       ],
       "skinStyles": {
         "vector": "skins/vector.less",

--- a/extensions/ArchLinux/modules/arch_common.less
+++ b/extensions/ArchLinux/modules/arch_common.less
@@ -53,6 +53,14 @@ ul,
     padding: 2px;
 }
 
+/*
+ * Hide logos in the footer
+ * (they can be disabled in LocalSettings.php by setting $wgFooterIcons)
+ */
+#footer-icons {
+    display: none;
+}
+
 /* article Table of Contents */
 #toc,
 .toc,

--- a/extensions/ArchLinux/modules/arch_common.less
+++ b/extensions/ArchLinux/modules/arch_common.less
@@ -1,0 +1,64 @@
+/* general styling */
+body {
+    background: #f6f9fc;
+}
+
+body,
+#content,
+table,
+h1,
+h2,
+h3,
+h4,
+h5,
+pre,
+code,
+tt {
+    color: #222;
+}
+
+pre,
+code,
+tt {
+    background-color: #ebf1f5;
+    font-family: monospace;
+}
+
+pre {
+    border: 1px solid #bcd;
+    overflow: auto;
+}
+
+code,
+tt {
+    /* Inline-block prevents code from wrapping when starting too close to the end of a line; it also lets select the entire code line with a triple click */
+    display: inline-block;
+    padding: 0 0.3em;
+    /* A border would be inherited by the default style sheets, but we don't want it */
+    border-width: 0;
+    border-radius: 0;
+}
+
+ul,
+.portlet ul {
+    list-style-image: none;
+}
+
+#bodyContent table {
+    border-collapse: collapse;
+    padding: 2px;
+}
+
+#bodyContent td {
+    padding: 2px;
+}
+
+/* article Table of Contents */
+#toc,
+.toc,
+.mw-warning,
+.toccolours {
+    background-color: #f9faff;
+    border: 1px solid #d7dfe3;
+}
+

--- a/extensions/ArchLinux/modules/arch_common.less
+++ b/extensions/ArchLinux/modules/arch_common.less
@@ -117,3 +117,14 @@ a.new,
 #mw-navigation li.new a {
     color: #b00 !important;
 }
+
+/*
+ * Use the same icon for all external links
+ * The default MediaWiki style assigns icons only to external links and not interwiki links,
+ * so we use this to have an icon for all links pointing to external sites.
+ */
+.mw-body-content a.external,
+.mw-body-content a.extiw {
+    background: url(/resources/src/mediawiki.skinning/images/external-ltr.png) center right no-repeat;
+    padding-right: 13px;
+}

--- a/extensions/ArchLinux/modules/arch_common.less
+++ b/extensions/ArchLinux/modules/arch_common.less
@@ -53,6 +53,11 @@ ul,
     padding: 2px;
 }
 
+/* content borders */
+div#content {
+    border: 1px solid #ccc;
+}
+
 /*
  * Hide logos in the footer
  * (they can be disabled in LocalSettings.php by setting $wgFooterIcons)

--- a/extensions/ArchLinux/modules/arch_common.less
+++ b/extensions/ArchLinux/modules/arch_common.less
@@ -62,7 +62,7 @@ ul,
     border: 1px solid #d7dfe3;
 }
 
-/* links (including page tabs and personal toolbar) */
+/* Make all links coming from the rendered wiki markup bold */
 #bodyContent > div.mw-content-ltr a,
 #bodyContent > div.mw-content-rtl a,
 #wikiPreview > div.mw-content-ltr a,
@@ -75,47 +75,45 @@ ul,
 #bodyContent #pagehistory a {
     font-weight: normal;
 }
-a:link,
-#toc a,
-#p-cactions li a,
-#p-personal li a,
-#p-cactions li a:visited,
-#p-personal li a:visited,
-#bodyContent a.external,
-#bodyContent a.extiw {
+
+/* Colors of links in the content, MediaWiki navigation and the footer */
+#content,
+#mw-navigation li:not(.new),  // Vector
+#mw-panel li:not(.new),       // Vector
+#column-one li:not(.new),     // MonoBook
+#footer {
+  a:not(.new) {
     text-decoration: none;
-    outline: none;
-    color: #07b;
-}
-a:visited,
-#bodyContent a:visited.external {
-    color: #666;
-}
-a:hover,
-#p-personal li a:hover,
-#bodyContent #toc a:hover,
-#bodyContent a:hover.external {
+    color: #07b !important;
+  }
+
+  a:not(.new):hover {
     text-decoration: underline;
     background-color: transparent;
-    color: #999;
-}
-a:focus,
-a:active,
-#toc a:focus,
-#toc a:active,
-#p-cactions li a:focus,
-#p-cactions li a:active,
-#p-personal li a:focus,
-#p-personal li a:active,
-#bodyContent a:focus.external,
-#bodyContent a:active.external,
-#bodyContent a:focus.extiw,
-#bodyContent a:active.extiw {
+    color: #999 !important;
+  }
+
+  a:active, a:focus,
+  /* a:hover overrides a:active, which we don't want' */
+  a:active:hover, a:focus:hover {
     color: #e90 !important;
-}
-a.new,
-#p-cactions .new a,
-#p-personal a.new {
-    color: #b00 !important;
+  }
 }
 
+/* Color of visited links for content and left column
+ * (not for MediaWiki navigation elements above the page) */
+#content,
+#mw-panel li:not(.new),       // Vector
+#p-navigation li:not(.new),   // MonoBook
+#p-tb li:not(.new)            // MonoBook
+{
+  a:not(.new):visited {
+    color: #666 !important;
+  }
+}
+
+/* Color for links to inexistent pages */
+a.new,
+#mw-navigation li.new a {
+    color: #b00 !important;
+}

--- a/extensions/ArchLinux/modules/arch_common.less
+++ b/extensions/ArchLinux/modules/arch_common.less
@@ -62,3 +62,60 @@ ul,
     border: 1px solid #d7dfe3;
 }
 
+/* links (including page tabs and personal toolbar) */
+#bodyContent > div.mw-content-ltr a,
+#bodyContent > div.mw-content-rtl a,
+#wikiPreview > div.mw-content-ltr a,
+#wikiPreview > div.mw-content-rtl a {
+    font-weight: bold;
+}
+#bodyContent #toc a,
+#bodyContent .special li > a,
+#bodyContent .special li span a,
+#bodyContent #pagehistory a {
+    font-weight: normal;
+}
+a:link,
+#toc a,
+#p-cactions li a,
+#p-personal li a,
+#p-cactions li a:visited,
+#p-personal li a:visited,
+#bodyContent a.external,
+#bodyContent a.extiw {
+    text-decoration: none;
+    outline: none;
+    color: #07b;
+}
+a:visited,
+#bodyContent a:visited.external {
+    color: #666;
+}
+a:hover,
+#p-personal li a:hover,
+#bodyContent #toc a:hover,
+#bodyContent a:hover.external {
+    text-decoration: underline;
+    background-color: transparent;
+    color: #999;
+}
+a:focus,
+a:active,
+#toc a:focus,
+#toc a:active,
+#p-cactions li a:focus,
+#p-cactions li a:active,
+#p-personal li a:focus,
+#p-personal li a:active,
+#bodyContent a:focus.external,
+#bodyContent a:active.external,
+#bodyContent a:focus.extiw,
+#bodyContent a:active.extiw {
+    color: #e90 !important;
+}
+a.new,
+#p-cactions .new a,
+#p-personal a.new {
+    color: #b00 !important;
+}
+

--- a/extensions/ArchLinux/modules/archnavbar/archnavbar.less
+++ b/extensions/ArchLinux/modules/archnavbar/archnavbar.less
@@ -26,3 +26,6 @@ html > body #archnavbarlogo { background: url('archlogo.svg') no-repeat !importa
 /* style the links */
 #archnavbar ul#archnavbarlist li a { color: #999; font-weight: bold !important; text-decoration: none !important; }
 #archnavbar ul li a:hover { color: white !important; text-decoration: underline !important; }
+
+/* highlight current website in the navbar */
+#archnavbar ul li.anb-selected a { color: white !important; }

--- a/extensions/ArchLinux/modules/skins/monobook.less
+++ b/extensions/ArchLinux/modules/skins/monobook.less
@@ -12,6 +12,13 @@ h1 {
     top: 27px;
 }
 
+/* use the same color for the border of all tabs */
+#p-cactions {
+    li, li.selected {
+        border-color: #ccc;
+    }
+}
+
 /* bump down the main content to make room for navbar */
 #content {
     top: 10px;

--- a/extensions/ArchLinux/modules/skins/monobook.less
+++ b/extensions/ArchLinux/modules/skins/monobook.less
@@ -38,12 +38,6 @@ div#column-one {
     padding-top: 36px;
 }
 
-/* disable footer logos  TODO: see if this can be done in LocalSettings.php */
-#f-poweredbyico,
-#f-copyrightico {
-    display: none;
-}
-
 /* clean up the footer */
 div#footer {
     color: #888;

--- a/extensions/ArchLinux/modules/skins/monobook.less
+++ b/extensions/ArchLinux/modules/skins/monobook.less
@@ -22,14 +22,6 @@ div#globalWrapper {
     width: 99%;
 }
 
-/* sidebar menus and content borders */
-.pBody {
-    border: 1px solid #ddd;
-}
-div#content {
-    border: 1px solid #ccc;
-}
-
 /* disable default mediawiki logo and close the gap it leaves behind */
 #p-logo {
     display: none !important;

--- a/extensions/ArchLinux/modules/skins/monobook.less
+++ b/extensions/ArchLinux/modules/skins/monobook.less
@@ -40,13 +40,14 @@ div#column-one {
 
 /* clean up the footer */
 div#footer {
-    color: #888;
+    color: #333;
     background-color: transparent;
     border-top: none;
     border-bottom: none;
-}
-
-/* bring footer text inline with content */
-#footer ul {
-    margin-left: 170px;
+    /* bring footer text inline with content */
+    margin-left: 12.2em;
+    padding: 0em 1em;
+    ul {
+        margin-left: 0;
+    }
 }

--- a/extensions/ArchLinux/modules/skins/monobook.less
+++ b/extensions/ArchLinux/modules/skins/monobook.less
@@ -2,63 +2,6 @@ h1 {
     font-weight: bold;
 }
 
-/* links (including page tabs and personal toolbar) */
-#bodyContent > div.mw-content-ltr a,
-#bodyContent > div.mw-content-rtl a,
-#wikiPreview > div.mw-content-ltr a,
-#wikiPreview > div.mw-content-rtl a {
-    font-weight: bold;
-}
-#bodyContent #toc a,
-#bodyContent .special li > a,
-#bodyContent .special li span a,
-#bodyContent #pagehistory a {
-    font-weight: normal;
-}
-a:link,
-#toc a,
-#p-cactions li a,
-#p-personal li a,
-#p-cactions li a:visited,
-#p-personal li a:visited,
-#bodyContent a.external,
-#bodyContent a.extiw {
-    text-decoration: none;
-    outline: none;
-    color: #07b;
-}
-a:visited,
-#bodyContent a:visited.external {
-    color: #666;
-}
-a:hover,
-#p-personal li a:hover,
-#bodyContent #toc a:hover,
-#bodyContent a:hover.external {
-    text-decoration: underline;
-    background-color: transparent;
-    color: #999;
-}
-a:focus,
-a:active,
-#toc a:focus,
-#toc a:active,
-#p-cactions li a:focus,
-#p-cactions li a:active,
-#p-personal li a:focus,
-#p-personal li a:active,
-#bodyContent a:focus.external,
-#bodyContent a:active.external,
-#bodyContent a:focus.extiw,
-#bodyContent a:active.extiw {
-    color: #e90 !important;
-}
-a.new,
-#p-cactions .new a,
-#p-personal a.new {
-    color: #b00 !important;
-}
-
 /* bump down the personal toolbar (top menu) */
 #p-personal {
     top: 5px;

--- a/extensions/ArchLinux/modules/skins/monobook.less
+++ b/extensions/ArchLinux/modules/skins/monobook.less
@@ -171,8 +171,3 @@ div#footer {
 #footer ul {
     margin-left: 170px;
 }
-
-/* highlight current website in the navbar */
-#archnavbar ul li.anb-selected a {
-    color: white !important;
-}

--- a/extensions/ArchLinux/modules/skins/monobook.less
+++ b/extensions/ArchLinux/modules/skins/monobook.less
@@ -1,55 +1,5 @@
-/* general styling */
-body {
-    background: #f6f9fc;
-}
-body,
-#content,
-table,
-h1,
-h2,
-h3,
-h4,
-h5,
-pre,
-code,
-tt {
-    color: #222;
-}
 h1 {
     font-weight: bold;
-}
-pre,
-code,
-tt {
-    background-color: #ebf1f5;
-    font-family: monospace;
-}
-pre {
-    border: 1px solid #bcd;
-    overflow: auto;
-}
-code,
-tt {
-    /* Inline-block prevents code from wrapping when starting too close to the
-    end of a line; it also lets select the entire code line with a triple
-    click */
-    display: inline-block;
-    padding: 0 0.3em;
-    /* A border would be inherited by the default style sheets, but we don't
-    want it */
-    border-width: 0;
-    border-radius: 0;
-}
-ul,
-.portlet ul {
-    list-style-image: none;
-}
-#bodyContent table {
-    border-collapse: collapse;
-    padding: 2px;
-}
-#bodyContent td {
-    padding: 2px;
 }
 
 /* links (including page tabs and personal toolbar) */
@@ -127,14 +77,6 @@ a.new,
 /* shrink the content just enough to show off the borders */
 div#globalWrapper {
     width: 99%;
-}
-
-/* article Table of Contents */
-#toc,
-.toc,
-.mw-warning {
-    background-color: #f9faff;
-    border: 1px solid #d7dfe3;
 }
 
 /* sidebar menus and content borders */

--- a/extensions/ArchLinux/modules/skins/vector.less
+++ b/extensions/ArchLinux/modules/skins/vector.less
@@ -28,6 +28,9 @@ div.vectorTabs {
     border: 1px solid #ccc;
     border-bottom: 1px solid #fff;
     background-color: #fff;
+    span {
+        background: none;
+    }
   }
 }
 

--- a/extensions/ArchLinux/modules/skins/vector.less
+++ b/extensions/ArchLinux/modules/skins/vector.less
@@ -17,10 +17,6 @@ div#mw-panel {
 div.vectorTabs {
   padding-left: 0;
 
-  * {
-    background-image: none !important;
-  }
-
   ul li {
     background: none;
     border: 1px solid #f6f9fc;

--- a/extensions/ArchLinux/modules/skins/vector.less
+++ b/extensions/ArchLinux/modules/skins/vector.less
@@ -39,10 +39,6 @@ div#mw-head h3 {
   margin-top: -2px;
 }
 
-#footer-icons {
-  display: none;
-}
-
 #content pre {
   word-break: break-all;
 }

--- a/extensions/ArchLinux/modules/skins/vector.less
+++ b/extensions/ArchLinux/modules/skins/vector.less
@@ -10,10 +10,6 @@ div#mw-panel {
   display: none;
 }
 
-body {
-  background: #f6f9fc;
-}
-
 #mw-page-base {
   background: none;
 }

--- a/extensions/ArchLinux/modules/skins/vector.less
+++ b/extensions/ArchLinux/modules/skins/vector.less
@@ -14,24 +14,6 @@ div#mw-panel {
   background: none;
 }
 
-#content,
-#mw-navigation li:not(.new),
-#footer {
-  a:not(.new) {
-    text-decoration: none !important;
-    color: #07b !important;
-  }
-
-  a:hover {
-    text-decoration: underline !important;
-    color: #666 !important;
-  }
-
-  a:active {
-    color: #e90 !important;
-  }
-}
-
 div.vectorTabs {
   padding-left: 0;
 

--- a/extensions/ArchLinux/modules/skins/vector.less
+++ b/extensions/ArchLinux/modules/skins/vector.less
@@ -65,10 +65,6 @@ div#mw-head h3 {
   display: none;
 }
 
-#archnavbar ul li.anb-selected a {
-  color: white !important;
-}
-
 #content pre {
   word-break: break-all;
 }

--- a/extensions/ArchLinux/modules/skins/vector.less
+++ b/extensions/ArchLinux/modules/skins/vector.less
@@ -20,12 +20,12 @@ div.vectorTabs {
   ul li {
     background: none;
     border: 1px solid #f6f9fc;
-    border-bottom: 1px solid #a7d7f9;
+    border-bottom: 1px solid #ccc;
     margin-top: -2px;
   }
 
   li.selected {
-    border: 1px solid #a7d7f9;
+    border: 1px solid #ccc;
     border-bottom: 1px solid #fff;
     background-color: #fff;
   }


### PR DESCRIPTION
There is no reason to ship vastly different stylesheets for the two supported skins (see [monobook.less](https://github.com/archlinux/archwiki/blob/master/extensions/ArchLinux/modules/skins/monobook.less) and [vector.less](https://github.com/archlinux/archwiki/blob/master/extensions/ArchLinux/modules/skins/vector.less)), so I moved the common rules from `monobook.less` (which was `arch.css` originally) into `arch_common.less`.

I also made some changes to make the rules for links simpler and more consistent. In the last commits also made some visual tweaks like using the same color in both skins for the border around content.