### PR TITLE
Stylesheet updates

### DIFF
--- a/extensions/ArchLinux/modules/arch_common.less
+++ b/extensions/ArchLinux/modules/arch_common.less
@@ -1,61 +1,62 @@
+@import 'arch_definitions';
+
 /* general styling */
 body {
-    background: #f6f9fc;
+    background: @body-background-color;
 }
 
-body,
-#content,
-table,
-h1,
-h2,
-h3,
-h4,
-h5,
-pre,
-code,
-tt {
-    color: #222;
-}
+#content {
+    background: @content-background-color;
+    border: @content-border-style;
 
-pre,
-code,
-tt {
-    background-color: #ebf1f5;
-    font-family: monospace;
-}
+    table,
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    pre,
+    code,
+    tt {
+        color: @text-color;
+    }
 
-pre {
-    border: 1px solid #bcd;
-    overflow: auto;
-}
+    ul {
+        list-style-image: none;
+    }
 
-code,
-tt {
-    /* Inline-block prevents code from wrapping when starting too close to the end of a line; it also lets select the entire code line with a triple click */
-    display: inline-block;
-    padding: 0 0.3em;
-    /* A border would be inherited by the default style sheets, but we don't want it */
-    border-width: 0;
-    border-radius: 0;
-}
+    table {
+        border-collapse: collapse;
+        padding: 2px;
+    }
 
-ul,
-.portlet ul {
-    list-style-image: none;
-}
+    td {
+        padding: 2px;
+    }
 
-#bodyContent table {
-    border-collapse: collapse;
-    padding: 2px;
-}
+    pre {
+        border: @code-border-style;
+        overflow: auto;
+        word-break: break-all;
+        white-space: pre-wrap !important;
+    }
 
-#bodyContent td {
-    padding: 2px;
-}
+    pre,
+    code,
+    tt {
+        background-color: @code-background-color;
+        font-family: monospace;
+    }
 
-/* content borders */
-div#content {
-    border: 1px solid #ccc;
+    code,
+    tt {
+        /* Inline-block prevents code from wrapping when starting too close to the end of a line; it also lets select the entire code line with a triple click */
+        display: inline-block;
+        padding: 0 0.3em;
+        /* A border would be inherited by the default style sheets, but we don't want it */
+        border-width: 0;
+        border-radius: 0;
+    }
 }
 
 /*
@@ -66,13 +67,17 @@ div#content {
     display: none;
 }
 
+#footer {
+    color: @footer-text-color;
+}
+
 /* article Table of Contents */
 #toc,
 .toc,
 .mw-warning,
 .toccolours {
-    background-color: #f9faff;
-    border: 1px solid #d7dfe3;
+    background-color: @toc-background-color;
+    border: @toc-border-style;
 }
 
 /* Make all links coming from the rendered wiki markup bold */
@@ -97,19 +102,19 @@ div#content {
 #footer {
   a:not(.new) {
     text-decoration: none;
-    color: #07b !important;
+    color: @link-color-normal !important;
   }
 
   a:not(.new):hover {
     text-decoration: underline;
     background-color: transparent;
-    color: #999 !important;
+    color: @link-color-hover !important;
   }
 
   a:active, a:focus,
   /* a:hover overrides a:active, which we don't want' */
   a:active:hover, a:focus:hover {
-    color: #e90 !important;
+    color: @link-color-active !important;
   }
 }
 
@@ -121,14 +126,14 @@ div#content {
 #p-tb li:not(.new)            // MonoBook
 {
   a:not(.new):visited {
-    color: #666 !important;
+    color: @link-color-visited !important;
   }
 }
 
 /* Color for links to inexistent pages */
 a.new,
 #mw-navigation li.new a {
-    color: #b00 !important;
+    color: @link-color-new !important;
 }
 
 /*

--- a/extensions/ArchLinux/modules/arch_common.less
+++ b/extensions/ArchLinux/modules/arch_common.less
@@ -132,7 +132,10 @@ body {
 
 /* Color for links to inexistent pages */
 a.new,
-#mw-navigation li.new a {
+a.new:visited,
+#mw-navigation li.new a,         // Vector
+#mw-navigation li.new a:visited  // Vector
+{
     color: @link-color-new !important;
 }
 

--- a/extensions/ArchLinux/modules/arch_common.less
+++ b/extensions/ArchLinux/modules/arch_common.less
@@ -1,3 +1,7 @@
+/*
+ * Common stylesheets applied to all skins.
+ */
+
 @import 'arch_definitions';
 
 /* general styling */

--- a/extensions/ArchLinux/modules/arch_definitions.less
+++ b/extensions/ArchLinux/modules/arch_definitions.less
@@ -6,7 +6,8 @@
 
 @body-background-color: #f6f9fc;
 @content-background-color: #fff;
-@content-border-style: 1px solid #ccc;
+@content-border-width: 1px;
+@content-border-style: @content-border-width solid #ccc;
 @text-color: #222;
 @code-background-color: #ebf1f5;
 @code-border-style: 1px solid #bcd;

--- a/extensions/ArchLinux/modules/arch_definitions.less
+++ b/extensions/ArchLinux/modules/arch_definitions.less
@@ -1,0 +1,21 @@
+/*
+ * This file should contain only common LESS definitions, which need to be
+ * imported in other .less files. Common stylesheets do not belong here, they
+ * should be added to files present in the "styles" array in extension.json.
+ */
+
+@body-background-color: #f6f9fc;
+@content-background-color: #fff;
+@content-border-style: 1px solid #ccc;
+@text-color: #222;
+@code-background-color: #ebf1f5;
+@code-border-style: 1px solid #bcd;
+@toc-background-color: #f9faff;
+@toc-border-style: 1px solid #d7dfe3;
+@footer-text-color: #333;
+
+@link-color-normal: #07b;
+@link-color-hover: #999;
+@link-color-active: #e90;
+@link-color-visited: #666;
+@link-color-new: #b00;

--- a/extensions/ArchLinux/modules/skins/monobook.less
+++ b/extensions/ArchLinux/modules/skins/monobook.less
@@ -1,3 +1,5 @@
+@import '../arch_definitions';
+
 h1 {
     font-weight: bold;
 }
@@ -12,16 +14,16 @@ h1 {
     top: 27px;
 }
 
-/* use the same color for the border of all tabs */
-#p-cactions {
-    li, li.selected {
-        border-color: #ccc;
-    }
-}
-
 /* bump down the main content to make room for navbar */
 #content {
     top: 10px;
+}
+
+/* use the same color for the border of all tabs */
+#p-cactions {
+    li, li.selected {
+        border: @content-border-style;
+    }
 }
 
 /* shrink the content just enough to show off the borders */
@@ -39,7 +41,6 @@ div#column-one {
 
 /* clean up the footer */
 div#footer {
-    color: #333;
     background-color: transparent;
     border-top: none;
     border-bottom: none;

--- a/extensions/ArchLinux/modules/skins/vector.less
+++ b/extensions/ArchLinux/modules/skins/vector.less
@@ -2,9 +2,6 @@
 
 div#mw-head {
   top: 65px;
-  h3 {
-    margin-top: -2px;
-  }
 }
 
 div#mw-panel {
@@ -19,23 +16,43 @@ div#mw-panel {
   background: none;
 }
 
+/* fix vertical position of tabs */
+div.vectorTabs, div.vectorMenu {
+  margin-top: -2 * @content-border-width;
+}
+
 div.vectorTabs {
   padding-left: 0;
 
-  ul li {
+  /* remove background with color gradient */
+  ul, ul li {
     background: none;
-    border: 1px solid @body-background-color;
-    border-bottom: @content-border-style;
-    margin-top: -2px;
+  }
+
+  /* invisible border to align well with the selected tab */
+  ul li {
+    border: @content-border-width;
   }
 
   li.selected {
+    /* border around the tab matches content, at the bottom we override the
+     * content border with the background color
+     */
     border: @content-border-style;
-    border-bottom: 1px solid @content-background-color;
+    border-bottom-color: @content-background-color;
+    /* background of the selected tab should match the content */
     background-color: @content-background-color;
+    /* remove background with the vertical separator */
     span {
         background: none;
     }
+  }
+
+  /* Let the left border of the selected tab overlap with the vertical bar
+   * coming from the background image of the previous tab.
+   */
+  li:not(:first-child).selected {
+    margin-left: -2 * @content-border-width;
   }
 }
 

--- a/extensions/ArchLinux/modules/skins/vector.less
+++ b/extensions/ArchLinux/modules/skins/vector.less
@@ -40,7 +40,13 @@ div.vectorTabs {
 }
 
 @media screen and ( max-width: @deviceWidthTablet ) {
+  /* fix position of personal navigation bar */
+  div#p-personal {
+    top: unset;
+  }
+
+  /* remove useless blank space at the bottom */
   div#mw-panel {
-    margin-top: 65px;
+    padding-top: 0;
   }
 }

--- a/extensions/ArchLinux/modules/skins/vector.less
+++ b/extensions/ArchLinux/modules/skins/vector.less
@@ -1,5 +1,10 @@
+@import '../arch_definitions';
+
 div#mw-head {
   top: 65px;
+  h3 {
+    margin-top: -2px;
+  }
 }
 
 div#mw-panel {
@@ -19,31 +24,19 @@ div.vectorTabs {
 
   ul li {
     background: none;
-    border: 1px solid #f6f9fc;
-    border-bottom: 1px solid #ccc;
+    border: 1px solid @body-background-color;
+    border-bottom: @content-border-style;
     margin-top: -2px;
   }
 
   li.selected {
-    border: 1px solid #ccc;
-    border-bottom: 1px solid #fff;
-    background-color: #fff;
+    border: @content-border-style;
+    border-bottom: 1px solid @content-background-color;
+    background-color: @content-background-color;
     span {
         background: none;
     }
   }
-}
-
-div#mw-head h3 {
-  margin-top: -2px;
-}
-
-#content pre {
-  word-break: break-all;
-}
-
-pre, .mw-code {
-  white-space: pre-wrap !important;
 }
 
 @media screen and ( max-width: @deviceWidthTablet ) {


### PR DESCRIPTION
Continuing #10, I tried to make the stylesheets more generic. There is now a new file `arch_definitions.less` (for now it contains just the definitions of colors and border styles), which is imported in all other LESS files. Most problematic is the matching of links, which have to be matched carefuly even in the skin's navigation elements, but each skin uses different class names. Not sure what is the best solution...

I also slightly improved the styling of Vector tabs and added comments for future reference.