### PR TITLE
Add extensions/TitleKey

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,3 +6,6 @@
 	path = extensions/AbuseFilter
 	url = https://github.com/wikimedia/mediawiki-extensions-AbuseFilter.git
 	branch = REL1_29
+[submodule "extensions/TitleKey"]
+	path = extensions/TitleKey
+	url = https://github.com/wikimedia/mediawiki-extensions-TitleKey.git

--- a/LocalSettings.archlinux.org.php
+++ b/LocalSettings.archlinux.org.php
@@ -296,6 +296,9 @@ wfLoadExtension( 'ParserFunctions' );
 wfLoadExtension( 'Interwiki' );
 $wgGroupPermissions['sysop']['interwiki'] = true;
 
+# TitleKey extension
+wfLoadExtension( 'TitleKey' );
+
 ##
 ## Temporary settings for maintenance
 ##


### PR DESCRIPTION
Fixes FS#53745

This would enable Opensearch API queries to be able to search the wiki
using a case-insensitive search, for example, the Arch Linux IRC bot "phrik".

...

Note that the maintenance scripts would need to be run in order to set
up TitleKey, which according to the [documentation](https://www.mediawiki.org/wiki/Extension:TitleKey#Installation) means running:
`php extensions/TitleKey/rebuildTitleKeys.php`

On the other hand, git README in git suggests that this is hooked into
the "standard updaters" so running mediawiki's global
`php maintenance/update.php`
should work as well.

I'm not sure how archwiki is deployed, it's not in ansible yet, so
hopefully someone who knows more about mediawiki than I do can confirm
this is correct.