### PR TITLE
Fix loading of extensions + start migration towards HTML5-style link fragments

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,5 +16,5 @@
 	branch = REL1_31
 [submodule "extensions/Nuke"]
 	path = extensions/Nuke
-	url = git@github.com:wikimedia/mediawiki-extensions-Nuke.git
+	url = https://github.com/wikimedia/mediawiki-extensions-Nuke.git
 	branch = REL1_31

--- a/.gitmodules
+++ b/.gitmodules
@@ -14,3 +14,7 @@
 	path = extensions/BounceHandler
 	url = https://github.com/wikimedia/mediawiki-extensions-BounceHandler.git
 	branch = REL1_31
+[submodule "extensions/Nuke"]
+	path = extensions/Nuke
+	url = git@github.com:wikimedia/mediawiki-extensions-Nuke.git
+	branch = REL1_31

--- a/LocalSettings.archlinux.org.php
+++ b/LocalSettings.archlinux.org.php
@@ -86,6 +86,13 @@ $wgNamespacesWithSubpages[NS_MAIN] = true;
 $wgAllowUserJs = true;
 $wgAllowUserCss = true;
 
+# add secondary HTML5-style anchors for sections
+$wgFragmentMode = [ 'legacy', 'html5' ];
+# TODO: migrate to HTML5-style primary anchors
+# (can be done in about a week when the HTML cache is naturally renewed,
+# (at least most of the cachced pages) or we can manually purge all pages)
+//$wgFragmentMode = [ 'html5', 'legacy' ];
+
 
 ##
 ## Database settings

--- a/LocalSettings.archlinux.org.php
+++ b/LocalSettings.archlinux.org.php
@@ -262,10 +262,10 @@ $wgHiddenPrefs[] = "forceeditsummary";
 ## Additional extensions
 ##
 
-require_once( "$IP/extensions/Nuke/Nuke.php" );
+wfLoadExtension( 'Nuke' );
 
 # AbuseFilter extension
-require_once "$IP/extensions/AbuseFilter/AbuseFilter.php";
+wfLoadExtension( 'AbuseFilter' );
 $wgGroupPermissions['sysop']['abusefilter-modify'] = true;
 $wgGroupPermissions['*']['abusefilter-log-detail'] = true;
 $wgGroupPermissions['*']['abusefilter-view'] = true;


### PR DESCRIPTION
I added a git submodule for the Nuke extension and used the `wfLoadExtension` function for extension loading as recommended by MediaWiki.

The migration to HTML5-style fragment links (see [Manual:$wgFragmentMode](https://www.mediawiki.org/wiki/Manual:$wgFragmentMode)) is two-step, first the `html5` mode is enabled as secondary and then it is switched to the primary mode. I will do this in another PR about a week after this one is merged.