### PR TITLE
Finish migration to HTML5-style link fragments

### DIFF
--- a/LocalSettings.archlinux.org.php
+++ b/LocalSettings.archlinux.org.php
@@ -86,12 +86,8 @@ $wgNamespacesWithSubpages[NS_MAIN] = true;
 $wgAllowUserJs = true;
 $wgAllowUserCss = true;
 
-# add secondary HTML5-style anchors for sections
-$wgFragmentMode = [ 'legacy', 'html5' ];
-# TODO: migrate to HTML5-style primary anchors
-# (can be done in about a week when the HTML cache is naturally renewed,
-# (at least most of the cachced pages) or we can manually purge all pages)
-//$wgFragmentMode = [ 'html5', 'legacy' ];
+# Section anchors: use HTML5-style anchors as primary, legacy as fallbback
+$wgFragmentMode = [ 'html5', 'legacy' ];
 
 
 ##


### PR DESCRIPTION
I think that since #17, most of the pages (or at least the frequently visited ones) were already purged from the cache due to editing, so there shouldn't be a lot of broken links after this is merged.