### PR TITLE
Add group permissions to define user roles and access levels

### DIFF
--- a/LocalSettings.archlinux.org.php
+++ b/LocalSettings.archlinux.org.php
@@ -210,7 +210,23 @@ $wgArchNavBarSelectedDefault = 'Wiki';
 $wgFooterIcons = ['copyright' => ['copyright' => '']];
 
 ##
-## Access control settings
+## User roles
+##
+## User roles are groups without permissions: they only serve to clarify the
+## main function of the user in the wiki, and they must be associated to
+## specific access levels (see below) as needed.
+##
+
+$wgGroupPermissions[] = 'maintainer';
+
+
+##
+## Access levels
+##
+## These groups shouldn't be used to define the _role_ of users, but only the
+## extent of the permissions that they have in the wiki; if a user is given
+## an access level greater than 'user', their role (see above) must be
+## specified as well.
 ##
 
 # disable anonymous editing
@@ -218,7 +234,7 @@ $wgEmailConfirmToEdit = true;
 $wgDisableAnonTalk = true;
 $wgGroupPermissions['*']['edit'] = false;
 
-# extra rights for admins
+# extra rights for sysop
 $wgGroupPermissions['sysop']['deleterevision']  = true;
 
 # disable uploads by normal users
@@ -227,17 +243,17 @@ $wgGroupPermissions['user']['reupload']        = false;
 $wgGroupPermissions['user']['reupload-shared'] = false;
 $wgGroupPermissions['autoconfirmed']['upload'] = false;
 
-# maintainers' rights
-$wgGroupPermissions['maintainer']['autopatrol'] = true;
-$wgGroupPermissions['maintainer']['patrol'] = true;
-$wgGroupPermissions['maintainer']['noratelimit'] = true;
-$wgGroupPermissions['maintainer']['suppressredirect'] = true;
-$wgGroupPermissions['maintainer']['rollback'] = true;
-$wgGroupPermissions['maintainer']['browsearchive'] = true;
-$wgGroupPermissions['maintainer']['apihighlimits'] = true;
-$wgGroupPermissions['maintainer']['unwatchedpages'] = true;
-$wgGroupPermissions['maintainer']['deletedhistory'] = true;
-$wgGroupPermissions['maintainer']['deletedtext'] = true;
+# co-sysop's rights
+$wgGroupPermissions['cosysop']['autopatrol'] = true;
+$wgGroupPermissions['cosysop']['patrol'] = true;
+$wgGroupPermissions['cosysop']['noratelimit'] = true;
+$wgGroupPermissions['cosysop']['suppressredirect'] = true;
+$wgGroupPermissions['cosysop']['rollback'] = true;
+$wgGroupPermissions['cosysop']['browsearchive'] = true;
+$wgGroupPermissions['cosysop']['apihighlimits'] = true;
+$wgGroupPermissions['cosysop']['unwatchedpages'] = true;
+$wgGroupPermissions['cosysop']['deletedhistory'] = true;
+$wgGroupPermissions['cosysop']['deletedtext'] = true;
 
 $wgEnableWriteAPI = true;
 # disable user account creation via API

--- a/LocalSettings.archlinux.org.php
+++ b/LocalSettings.archlinux.org.php
@@ -245,10 +245,8 @@ $wgAPIModules['createaccount'] = 'ApiDisabled';
 # remove 'writeapi' right from users
 $wgGroupPermissions['*']['writeapi'] = false;
 $wgGroupPermissions['user']['writeapi'] = false;
-# add 'writeapi' to autoconfirmed users, maintainers and admins
+# add 'writeapi' to autoconfirmed users
 $wgGroupPermissions['autoconfirmed']['writeapi'] = true;
-$wgGroupPermissions['maintainer']['writeapi'] = true;
-$wgGroupPermissions['sysop']['writeapi'] = true;
 # stricter conditions for 'autoconfirmed' promotion
 $wgAutoConfirmAge = 86400*3; // three days
 # require at least 20 normal edits before granting the 'writeapi' right

--- a/LocalSettings.archlinux.org.php
+++ b/LocalSettings.archlinux.org.php
@@ -255,6 +255,11 @@ $wgGroupPermissions['cosysop']['unwatchedpages'] = true;
 $wgGroupPermissions['cosysop']['deletedhistory'] = true;
 $wgGroupPermissions['cosysop']['deletedtext'] = true;
 
+# additional page-protection levels
+$wgRestrictionLevels[] = 'editprotected2';
+$wgGroupPermissions['sysop']['editprotected2'] = true;
+$wgGroupPermissions['cosysop']['editprotected2'] = true;
+
 $wgEnableWriteAPI = true;
 # disable user account creation via API
 $wgAPIModules['createaccount'] = 'ApiDisabled';

--- a/LocalSettings.archlinux.org.php
+++ b/LocalSettings.archlinux.org.php
@@ -218,6 +218,10 @@ $wgFooterIcons = ['copyright' => ['copyright' => '']];
 ##
 
 $wgGroupPermissions[] = 'maintainer';
+$wgGroupPermissions[] = 'translator';
+$wgGroupPermissions[] = 'archdev';
+$wgGroupPermissions[] = 'archtu';
+$wgGroupPermissions[] = 'archstaff';
 
 
 ##


### PR DESCRIPTION
This PR splits the concepts of **user roles** and **access levels** to clarify the function of users and help bureaucrats grant permissions as required, regardless of the role. This patch has already been discussed in the *arch-wiki-admins* ML and reached consensus among the participating wiki administrators in the current form.

*User roles* are groups without rights: they only serve to clarify the main function of the user in the wiki, and they must be associated to specific *access levels* as needed:
- **maintainer**: current wiki admininstrators + maintainers (i.e. anybody whose primary goal is to look after the wiki per se);
- **translator**: to be used to reward and encourage very active wiki translators (there have been a few that really spent innumerable hours on the project without any official acknowledgement);
- **archdev**: to group Arch Developers;
- **archtu**: to group Arch Trusted Users;
- **archstaff**: to group members of other sections of the Arch Community besides the ones above (e.g. forum admins, IRC ops...).

*Access levels* are groups that define the extent of the permissions that users have in the wiki, regardless of their role. MediaWiki defines some by default, but the following are most relevant:

- **sysop**: currently used to also define the wiki administrator role, however all users who need to access protected page need this access level, hence the current confusion;
- **cosysop** ([Wikipedia:Sysop](https://en.wikipedia.org/wiki/Sysop)): this is an intermediate access level that is currently associated to the *maintainer* group.

This system allows to keep only 2 page restriction levels (for *sysop*s and *cosysop*s), depending on the level of "trust" that the user has gained in the wiki. I don't think that it makes much sense to complicate things by having pages that only certain roles can edit: I think it's only a matter of trust, and if we have given some to somebody, we should be able to assume that they know what they can edit or not.

After merging the branch there are 2 changes that should be made as soon as possible in the wiki:

- Assign the *cosysop* group to all the previous non-admin *maintainer*s;
- Update the AbuseFilter rules accordingly.

With less urgency, the following steps are:

- Assign *sysop*-only users to proper roles;
- Create system messages for the new groups, and perhaps change the existing ones, especially those associated to *sysop* and *maintainer*;
- Reorganize the wiki pages related to user groups in accordance with the new configuration;
- Update the bots to handle the new groups.

--------------
### NOTE 1
I've also bundled a commit that removes the assignment of the **writeapi** right to *sysop* and *maintainer*/*cosysop* because it's also given to *autoconfirmed* (which is implicitly assigned to users in those groups), so it's redundant.

-------------
### NOTE 2
There's an alternative patch in (https://github.com/archlinux/archwiki/compare/master...kynikos:permissions1): it has a more conservative approach, but I think it handles the problem in a more complicated and inflexible way.