### PR TITLE
Set $wgCaptchaTriggers as true only for actions related to login/account creation

### DIFF
--- a/LocalSettings.archlinux.org.php
+++ b/LocalSettings.archlinux.org.php
@@ -331,7 +331,11 @@ $wgVERPdomainPart = "archlinux.org";
 # CAPTCHA
 # The dynamic $wgCaptchaQuestions is defined in the infrastructure repository
 wfLoadExtensions([ 'ConfirmEdit', 'ConfirmEdit/QuestyCaptcha' ]);
-$wgCaptchaTriggers = ['createaccount' => true];
+$wgCaptchaTriggers['edit'] = false;
+$wgCaptchaTriggers['create'] = false;
+$wgCaptchaTriggers['addurl'] = false;
+$wgCaptchaTriggers['createaccount'] = true;
+$wgCaptchaTriggers['badlogin'] = true;
 
 # Restrict expensive actions to logged in users
 wfLoadExtension( 'Lockdown' );


### PR DESCRIPTION
The commit 8070d35548873e0e48c1a67e9991adf7c8602c98 unintentionally changed the behaviour, since `$wgCaptchaTriggers['addurl']` is true by default. Users should not be asked captcha questions at all when editing, we have the AbuseFilter extension for preventing spam.