### PR TITLE
Add the DeveloperWiki namespace

### DIFF
--- a/LocalSettings.archlinux.org.php
+++ b/LocalSettings.archlinux.org.php
@@ -282,6 +282,22 @@ $wgHiddenPrefs[] = "forceeditsummary";
 
 
 ##
+## Additional namespaces
+##
+
+# DeveloperWiki
+define("NS_DEVELOPERWIKI", 3000);
+define("NS_DEVELOPERWIKI_TALK", 3001);
+$wgExtraNamespaces[NS_DEVELOPERWIKI] = "DeveloperWiki";
+$wgExtraNamespaces[NS_DEVELOPERWIKI_TALK] = "DeveloperWiki_talk";
+$wgNamespacesWithSubpages[NS_DEVELOPERWIKI] = true;
+$wgNamespacesWithSubpages[NS_DEVELOPERWIKI_TALK] = true;
+$wgContentNamespaces[] = NS_DEVELOPERWIKI;
+$wgNamespacesToBeSearchedDefault[NS_DEVELOPERWIKI] = true;
+$wgNamespaceProtection[NS_DEVELOPERWIKI] = array( 'editprotected2' );
+
+
+##
 ## Additional extensions
 ##
 


### PR DESCRIPTION
This has been a long time coming and now it's finally time to create a dedicated DeveloperWiki namespace.
This allows, among other things, to set a default protection level for the namespace, so that we don't have to protect each page individually.

**Please note that this change requires agreeing on the exact date and time of merging. There are actions that must be taken by the ArchWiki Administrators and their bots before and after the merge.**
Prior discussion and the current plan is in the wiki: https://wiki.archlinux.org/index.php/ArchWiki_talk:Maintenance_Team#Namespace_for_developers'_pages .

----

Per the [MediaWiki documentation](https://www.mediawiki.org/wiki/Manual:Using_custom_namespaces), the namespaces are created before loading extensions, except for the `ArchLinux` extension, but hopefully that doesn't matter. If it does matter, we can move the "Skin settings" down, just before "Additional extensions".
