### PR TITLE
Update access levels and user roles

### DIFF
--- a/LocalSettings.archlinux.org.php
+++ b/LocalSettings.archlinux.org.php
@@ -233,6 +233,12 @@ $wgGroupPermissions['*']['edit'] = false;
 
 # extra rights for sysop
 $wgGroupPermissions['sysop']['deleterevision']  = true;
+if ( isset( $wgGroupPermissions['interface-admin'] ) ) {
+    $wgGroupPermissions['sysop'] += $wgGroupPermissions['interface-admin'];
+}
+if ( isset( $wgGroupPermissions['suppress'] ) ) {
+    $wgGroupPermissions['sysop'] += $wgGroupPermissions['suppress'];
+}
 
 # disable uploads by normal users
 $wgGroupPermissions['user']['upload']          = false;

--- a/LocalSettings.archlinux.org.php
+++ b/LocalSettings.archlinux.org.php
@@ -283,14 +283,17 @@ $wgAutoConfirmAge = 86400*3; // three days
 $wgAutoConfirmCount = 20;
 
 # Enforce basic editing etiquette (FS#46190)
-# We set the defaults for "minordefault" (disabled) and "forceeditsummary"
-# (enabled) options and hide them from the user preferences dialog. Note that
-# hiding the user preferences with $wgHiddenPrefs results in everybody using
-# the defaults, regardless of the users' earlier preference.
+# We set the defaults for "minordefault" (disabled), "forceeditsummary"
+# (enabled) and "showrollbackconfirmation" (enabled) options and hide them
+# from the user preferences dialog. Note that hiding the user preferences with
+# $wgHiddenPrefs results in everybody using the defaults, regardless of the
+# users' earlier preference.
 $wgDefaultUserOptions["minordefault"] = 0;
 $wgDefaultUserOptions["forceeditsummary"] = 1;
+$wgDefaultUserOptions["showrollbackconfirmation"] = 1;
 $wgHiddenPrefs[] = "minordefault";
 $wgHiddenPrefs[] = "forceeditsummary";
+$wgHiddenPrefs[] = "showrollbackconfirmation";
 
 
 ##

--- a/LocalSettings.archlinux.org.php
+++ b/LocalSettings.archlinux.org.php
@@ -215,6 +215,7 @@ $wgGroupPermissions['translator'] = array();
 $wgGroupPermissions['archdev'] = array();
 $wgGroupPermissions['archtu'] = array();
 $wgGroupPermissions['archstaff'] = array();
+$wgGroupPermissions['administrator_fellow'] = array();
 
 
 ##

--- a/LocalSettings.archlinux.org.php
+++ b/LocalSettings.archlinux.org.php
@@ -252,10 +252,16 @@ $wgGroupPermissions['cosysop']['unwatchedpages'] = true;
 $wgGroupPermissions['cosysop']['deletedhistory'] = true;
 $wgGroupPermissions['cosysop']['deletedtext'] = true;
 
+# privileged's rights
+$wgGroupPermissions['privileged']['patrolmarks'] = true;
+$wgGroupPermissions['privileged']['noratelimit'] = true;
+$wgGroupPermissions['privileged']['suppressredirect'] = true;
+
 # additional page-protection levels
 $wgRestrictionLevels[] = 'editprotected2';
 $wgGroupPermissions['sysop']['editprotected2'] = true;
 $wgGroupPermissions['cosysop']['editprotected2'] = true;
+$wgGroupPermissions['privileged']['editprotected2'] = true;
 
 $wgEnableWriteAPI = true;
 # disable user account creation via API


### PR DESCRIPTION
This updates the access levels and user roles to better reflect the needs of the ArchWiki Maintenance Team.

The changes are:
- creation of a group called "`privileged`",
- assignment of lost and newly gained rights for sysops due to MediaWiki updates,
- enforced protection against accidental rollbacks,
- creation of new user roles for retired wiki administrators (`administrator_fellow`).