### PR TITLE
Add and load extensions required for wiki maintenance

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,3 +18,7 @@
 	path = extensions/Lockdown
 	url = https://github.com/wikimedia/mediawiki-extensions-Lockdown.git
 	branch = REL1_34
+[submodule "extensions/UserMerge"]
+	path = extensions/UserMerge
+	url = https://github.com/wikimedia/mediawiki-extensions-UserMerge.git
+	branch = REL1_34

--- a/LocalSettings.archlinux.org.php
+++ b/LocalSettings.archlinux.org.php
@@ -234,6 +234,7 @@ $wgGroupPermissions['*']['edit'] = false;
 
 # extra rights for sysop
 $wgGroupPermissions['sysop']['deleterevision']  = true;
+$wgGroupPermissions['sysop']['deletelogentry']  = true;
 if ( isset( $wgGroupPermissions['interface-admin'] ) ) {
     $wgGroupPermissions['sysop'] += $wgGroupPermissions['interface-admin'];
 }
@@ -377,6 +378,17 @@ $wgSpecialPageLockdown['Recentchangeslinked'] = [ 'user' ];
 $wgSpecialPageLockdown['Log'] = [ 'user' ];
 $wgSpecialPageLockdown['Diff'] = [ 'user' ];
 $wgActionLockdown['history'] = ['user'];
+
+
+# Renameuser extension
+wfLoadExtension( 'Renameuser' );
+$wgGroupPermissions['sysop']['renameuser'] = true;
+
+# UserMerge extension
+wfLoadExtension( 'UserMerge' );
+$wgGroupPermissions['sysop']['usermerge'] = true;
+# Allow merging users with "Anonymous" (user_id 0)
+$wgReservedUsernames[] = 'Anonymous';
 
 ##
 ## Temporary settings for maintenance


### PR DESCRIPTION
The following extensions will be added and loaded:
[Extension:Renameuser](https://www.mediawiki.org/wiki/Extension:Renameuser)
[Extension:UserMerge](https://www.mediawiki.org/wiki/Extension:UserMerge)

They are needed to allow removing users from the wiki while leaving minimal public traces in the interface.

Additionally grant the `deletelogentry` right to sysops to hide the actions of UserMerge from non-sysops.