### PR TITLE
Semi-protect the Template namespace

### DIFF
--- a/LocalSettings.archlinux.org.php
+++ b/LocalSettings.archlinux.org.php
@@ -76,9 +76,6 @@ $wgGitRepositoryViewers['.+projects\.archlinux\.org/vhosts/wiki\.archlinux\.org\
 $wgJobRunRate = 0;
 $wgRunJobsAsync = 1;
 
-# Enable subpages in the main namespace (FS#39668)
-$wgNamespacesWithSubpages[NS_MAIN] = true;
-
 # Enable support for userscripts and user-stylesheets (FS#46699)
 $wgAllowUserJs = true;
 $wgAllowUserCss = true;
@@ -298,8 +295,16 @@ $wgHiddenPrefs[] = "showrollbackconfirmation";
 
 
 ##
-## Additional namespaces
+## Namespaces
 ##
+
+# Main
+# Enable subpages in the main namespace (FS#39668)
+$wgNamespacesWithSubpages[NS_MAIN] = true;
+
+# Template
+# Restrict editing to autoconfirmed users
+$wgNamespaceProtection[NS_TEMPLATE] = array( 'editsemiprotected' );
 
 # DeveloperWiki
 define("NS_DEVELOPERWIKI", 3000);


### PR DESCRIPTION
It's easier than protecting each template individually. See https://wiki.archlinux.org/index.php/ArchWiki_talk:Maintenance_Team#Unprotecting_pages .

Additionally keep all namespace settings next to one another.