### PR TITLE
Disable Lockdown extension

### DIFF
--- a/LocalSettings.archlinux.org.php
+++ b/LocalSettings.archlinux.org.php
@@ -370,13 +370,13 @@ $wgCaptchaTriggers['createaccount'] = true;
 $wgCaptchaTriggers['badlogin'] = true;
 
 # Restrict expensive actions to logged in users
-wfLoadExtension( 'Lockdown' );
-$wgSpecialPageLockdown['Recentchanges'] = [ 'user' ];
-$wgSpecialPageLockdown['Newpages'] = [ 'user' ];
-$wgSpecialPageLockdown['Recentchangeslinked'] = [ 'user' ];
-$wgSpecialPageLockdown['Log'] = [ 'user' ];
-$wgSpecialPageLockdown['Diff'] = [ 'user' ];
-$wgActionLockdown['history'] = ['user'];
+#wfLoadExtension( 'Lockdown' );
+#$wgSpecialPageLockdown['Recentchanges'] = [ 'user' ];
+#$wgSpecialPageLockdown['Newpages'] = [ 'user' ];
+#$wgSpecialPageLockdown['Recentchangeslinked'] = [ 'user' ];
+#$wgSpecialPageLockdown['Log'] = [ 'user' ];
+#$wgSpecialPageLockdown['Diff'] = [ 'user' ];
+#$wgActionLockdown['history'] = ['user'];
 
 ##
 ## Temporary settings for maintenance


### PR DESCRIPTION
This restores public access to recent changes, page history etc. which
was disabled in September 2019 due to misbehaving crawlers/attack - see
commits f2c518d3df94e9ad6898fdd03cac982902f8ac36 and
8595e8d66141e608db794f1deef3e52cb36e5e78.

Let's hope that our robots.txt has been improved since then and the
server load will not increase much. If it proves to be still a problem,
this commit can be reverted and we will figure out better solution.