### PR TITLE
Remove useless settings from LocalSettings.archlinux.org.php

### DIFF
--- a/LocalSettings.archlinux.org.php
+++ b/LocalSettings.archlinux.org.php
@@ -16,17 +16,6 @@ if ( !defined( 'MEDIAWIKI' ) ) {
 }
 
 ##
-## LocalSettings.php
-##
-
-#$wgDBname     = "XXX";
-#$wgDBuser     = "XXX";
-#$wgDBpassword = "XXX";
-#$wgSecretKey  = "XXX";
-#$wgUpgradeKey = "XXX";
-
-
-##
 ## General settings
 ##
 
@@ -124,10 +113,6 @@ $wgUserEmailUseReplyTo = true;
 ##
 ## Cache and performance settings
 ##
-
-## Shared memory settings
-$wgMainCacheType    = CACHE_ACCEL;
-$wgMemCachedServers = array();
 
 ## Set $wgCacheDirectory to a writable directory on the web server
 ## to make your wiki go slightly faster. The directory should not


### PR DESCRIPTION
The main LocalSettings.php file is actually public (except for the secret values) in the Arch infrastructure repository:
https://gitlab.archlinux.org/archlinux/infrastructure/-/blob/master/roles/archwiki/templates/LocalSettings.php.j2

The `LocalSettings.php.j2` template includes clear configuration for the database access and memcached, so these comments and settings are not needed here anymore.

Actually, I'm thinking that we should move this entire file to the infrastructure repository to keep all settings in one place. It would also allow easier configuration of a testing wiki in [local containers](https://gitlab.archlinux.org/lahwaacz/infrastructure-testing) and in the future it would allow us to run ArchWiki based on packages instead of a monolithic git repo which is rather hard to update.

CC @kynikos, @nl6720, @jelly: what do you think guys?