### PR TITLE
Switch to WikiEditor as the editing interface and use CodeMirror for syntax highlighting

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,7 @@
 	path = extensions/UserMerge
 	url = https://github.com/wikimedia/mediawiki-extensions-UserMerge.git
 	branch = REL1_35
+[submodule "extensions/CodeMirror"]
+	path = extensions/CodeMirror
+	url = https://github.com/wikimedia/mediawiki-extensions-CodeMirror.git
+	branch = REL1_35

--- a/LocalSettings.archlinux.org.php
+++ b/LocalSettings.archlinux.org.php
@@ -395,6 +395,14 @@ $wgGroupPermissions['sysop']['usermerge'] = true;
 # Allow merging users with "Anonymous" (user_id 0)
 $wgReservedUsernames[] = 'Anonymous';
 
+# Improved interface for editing wikitext
+wfLoadExtension( 'WikiEditor' );
+
+# Syntax highlighting in WikiEditor
+wfLoadExtension( 'CodeMirror' );
+$wgDefaultUserOptions['usecodemirror'] = 1;
+
+
 ##
 ## Temporary settings for maintenance
 ##


### PR DESCRIPTION
Implements [FS#55828](https://bugs.archlinux.org/task/55828).