### PR TITLE
LocalSettings: enable new Vector by default

### DIFF
--- a/LocalSettings.archlinux.org.php
+++ b/LocalSettings.archlinux.org.php
@@ -186,6 +186,7 @@ $wgShellLocale = "en_US.utf8";
 wfLoadSkin( 'MonoBook' );
 wfLoadSkin( 'Vector' );
 $wgVectorResponsive = true;
+$wgVectorDefaultSkinVersion = '2';
 wfLoadExtension( 'ArchLinux' );
 $wgDefaultSkin = 'vector';
 $wgDefaultUserOptions['skin'] = 'vector';


### PR DESCRIPTION
Enable the ["modern" Vector look](https://www.mediawiki.org/wiki/Reading/Web/Desktop_Improvements) by default to make the wiki readable on mobile devices.
See also https://github.com/archlinux/archwiki/pull/44#issuecomment-912468063.