### PR TITLE
LocalSettings: enable new Vector by default for new accounts

### DIFF
--- a/LocalSettings.archlinux.org.php
+++ b/LocalSettings.archlinux.org.php
@@ -187,6 +187,7 @@ wfLoadSkin( 'MonoBook' );
 wfLoadSkin( 'Vector' );
 $wgVectorResponsive = true;
 $wgVectorDefaultSkinVersion = '2';
+$wgVectorDefaultSkinVersionForNewAccounts = '2';
 wfLoadExtension( 'ArchLinux' );
 $wgDefaultSkin = 'vector';
 $wgDefaultUserOptions['skin'] = 'vector';


### PR DESCRIPTION
Ensure that the wiki's look for new users matches what they see before registering (i.e. the default).

I missed this setting in #45.