### PR TITLE
Add support for Timeless skin in the ArchLinux extension

### DIFF
--- a/extensions/ArchLinux/extension.json
+++ b/extensions/ArchLinux/extension.json
@@ -30,6 +30,7 @@
         "arch_common.less"
       ],
       "skinStyles": {
+        "timeless": "skins/timeless.less",
         "vector": "skins/vector.less",
         "vector-2022": "skins/vector.less",
         "monobook": "skins/monobook.less"

--- a/extensions/ArchLinux/modules/skins/timeless.less
+++ b/extensions/ArchLinux/modules/skins/timeless.less
@@ -1,0 +1,95 @@
+@import '../arch_definitions';
+
+/* disable default mediawiki logo  */
+#p-logo {
+    display: none !important;
+}
+
+/* make room for archnavbar and disable fixed searchbar */
+body, #mw-content-container {
+    margin-top: 0;
+    background-color: @body-background-color;
+}
+#mw-content-container {
+    border-bottom: none;
+    padding-top: .5em;
+}
+#mw-header-hack, #mw-header-nav-hack {
+    display: none !important;
+}
+#mw-header-container {
+    position: initial;
+    background: @body-background-color;
+}
+#mw-content {
+    border: @content-border-style;
+}
+#content {
+    border: none;
+    background: transparent;
+}
+
+/* z-order fix */
+#personal-inner {
+    z-index: 200;
+}
+
+/* integrate footer into page background */
+#mw-footer {
+    padding-left: 16em;
+    padding-right: 18em;
+}
+#mw-footer > * {
+    font-size: .8em;
+}
+.mw-footer-container {
+    border-top: none;
+    line-height: 1;
+    color: inherit;
+    box-shadow: none;
+}
+.mw-footer-container a, a {
+    color: @link-color-normal;
+    &:active {
+        color: @link-color-active;
+    }
+    &:hover {
+        color: @link-color-hover;
+    }
+    &:visited {
+        color: @link-color-visited;
+        &:hover {
+            color: @link-color-hover;
+        }
+    }
+}
+
+
+/* fixes for specific widths */
+@media screen and (max-width:1339px) {
+    #mw-footer {
+        padding-right: 1em;
+    }
+}
+@media screen and (min-width:851px) and (max-width:1099px) {
+    #mw-footer {
+        padding-left: 1em;
+    }
+    #mw-content {
+        margin-top: 1.75em;
+    }
+}
+@media screen and (max-width:850px) {
+    #mw-footer {
+        padding-left: 1em;
+    }
+    #p-logo-text, #site-navigation h2, #site-tools h2, #user-tools h2 {
+        top: 75px;
+    }
+    .sidebar-inner, .dropdown {
+        top: 7.75em;
+    }
+    #menus-cover {
+        top: 65px;
+    }
+}


### PR DESCRIPTION
The switch to the new Vector skin caused some controversy among desktop wiki users. The Timeless skin is a more polished alternative responsive skin.
These changes should implement support for the Timeless skin in the ArchLinux extension. 

Here are some images of what it should approximately look like:
https://abload.de/gallery.php?key=kSKQLkmd
[![Bild skintimelessmediawikinmjww.png auf abload.de](https://abload.de/thumb/skintimelessmediawikinmjww.png)](https://abload.de/image.php?img=skintimelessmediawikinmjww.png) [![Bild skintimelessmediawikiayjd0.png auf abload.de](https://abload.de/thumb/skintimelessmediawikiayjd0.png)](https://abload.de/image.php?img=skintimelessmediawikiayjd0.png) [![Bild skintimelessmediawiki33js1.png auf abload.de](https://abload.de/thumb/skintimelessmediawiki33js1.png)](https://abload.de/image.php?img=skintimelessmediawiki33js1.png) [![Bild skintimelessmediawikigdkuq.png auf abload.de](https://abload.de/thumb/skintimelessmediawikigdkuq.png)](https://abload.de/image.php?img=skintimelessmediawikigdkuq.png) [![Bild skintimelessmediawikixtjfj.png auf abload.de](https://abload.de/thumb/skintimelessmediawikixtjfj.png)](https://abload.de/image.php?img=skintimelessmediawikixtjfj.png) [![Bild skintimelessmediawikin7j54.png auf abload.de](https://abload.de/thumb/skintimelessmediawikin7j54.png)](https://abload.de/image.php?img=skintimelessmediawikin7j54.png) 

It was not tested in an archwiki installation, but with this userscript on mediawiki.org:
https://gist.github.com/progandy/c3459f7e49c295e70563a44e0a27ba73