### PR TITLE
LocalSettings: allow adding additional links in the footer for the code of conduct and terms of service

### DIFF
--- a/LocalSettings.archlinux.org.php
+++ b/LocalSettings.archlinux.org.php
@@ -411,6 +411,18 @@ $wgDefaultUserOptions['usecodemirror'] = 1;
 
 
 ##
+## Additional links in the footer
+##
+
+$wgHooks['SkinAddFooterLinks'][] = function ( Skin $skin, string $key, array &$footerlinks ) {
+    if ( $key === 'places' ) {
+        $footerlinks['code-of-conduct'] = $skin->footerLink( 'code-of-conduct-desc', 'code-of-conduct-page' );
+        $footerlinks['terms-of-service'] = $skin->footerLink( 'terms-of-service-desc', 'terms-of-service-page' );
+    };
+};
+
+
+##
 ## Temporary settings for maintenance
 ##
 


### PR DESCRIPTION
See https://www.mediawiki.org/wiki/Manual:Footer#Add_links_to_the_footer.

Afterwards four system messages will need to be created:

* https://wiki.archlinux.org/title/MediaWiki:code-of-conduct-desc: `Code of conduct`
* https://wiki.archlinux.org/title/MediaWiki:code-of-conduct-page: `archlinux-service-agreements:code-of-conduct`
* https://wiki.archlinux.org/title/MediaWiki:terms-of-service-desc: `Terms of service`
* https://wiki.archlinux.org/title/MediaWiki:terms-of-service-page: `archlinux-service-agreements:terms-of-service`

----
Discussion: https://wiki.archlinux.org/title/ArchWiki_talk:Maintenance_Team#Adding_code_of_conduct_and_terms_of_service_links_in_the_footer.