### PR TITLE
LocalSettings: load CodeEditor for syntax highlighting in JavaScript and CSS pages

### DIFF
--- a/LocalSettings.archlinux.org.php
+++ b/LocalSettings.archlinux.org.php
@@ -409,6 +409,8 @@ wfLoadExtension( 'WikiEditor' );
 wfLoadExtension( 'CodeMirror' );
 $wgDefaultUserOptions['usecodemirror'] = 1;
 
+# Syntax highlighting for JavaScript, CSS and Lua
+wfLoadExtension( 'CodeEditor' );
 
 ##
 ## Temporary settings for maintenance


### PR DESCRIPTION
This provides syntax highlighting and validity checking for CSS and JavaScript.
It is useful for editing things such as Common.css, Common.js and abuse filters.

See https://www.mediawiki.org/wiki/Extension:CodeEditor.

----
Discussion: https://wiki.archlinux.org/title/ArchWiki_talk:Maintenance_Team#Syntax_highlighting_for_JavaScript_and_CSS_pages.