### PR TITLE
Improve the ArchLinux extension for the Vector 2022 skin

### DIFF
--- a/extensions/ArchLinux/modules/skins/vector.less
+++ b/extensions/ArchLinux/modules/skins/vector.less
@@ -42,7 +42,7 @@ nav.vector-menu-tabs {
   }
 }
 
-// New Vector; see https://www.mediawiki.org/wiki/Skin:Vector#wgVectorResponsive
+// Vector in responsive mode; https://www.mediawiki.org/wiki/Skin:Vector#wgVectorResponsive
 body.skin-vector.skin--responsive {
   nav.vector-menu-tabs {
     li.selected {
@@ -56,7 +56,10 @@ body.skin-vector.skin--responsive {
   li:not(:first-child).selected {
     margin-left: -1 * @content-border-width;
   }
+}
 
+// Vector legacy and Vector 2022
+body.skin-vector {
   // Set background color
   div.mw-page-container {
     background-color: @body-background-color;
@@ -68,7 +71,7 @@ body.skin-vector.skin--responsive {
   }
 }
 
-// Legacy Vector
+// Vector legacy
 body.skin-vector-legacy {
   div#mw-head,
   .mw-header {

--- a/extensions/ArchLinux/modules/skins/vector.less
+++ b/extensions/ArchLinux/modules/skins/vector.less
@@ -71,6 +71,19 @@ body.skin-vector {
   }
 }
 
+// Vector 2022
+body.skin-vector-2022 {
+  // Set background color
+  .vector-sticky-header {
+    background: @body-background-color;
+  }
+
+  // Match the font used in page title
+  .vector-sticky-header-context-bar-primary {
+    font-family: sans-serif;
+  }
+}
+
 // Vector legacy
 body.skin-vector-legacy {
   div#mw-head,


### PR DESCRIPTION
* Apply style to all modes of Vector (Vector 2022 with responsive mode enabled, Vector 2022 with responsive mode disabled, Vector legacy with responsive mode enabled and Vector legacy with responsive mode disabled).
* Use a sans serif font in Vector's sticky header and make it blue.

This requires https://github.com/archlinux/archwiki/pull/57.