### PR TITLE
Add DarkMode extension as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -26,3 +26,7 @@
 	path = extensions/FlarumAuth
 	url = https://github.com/archlinux-de/mediawiki-extensions-FlarumAuth.git
 	branch = REL1_39
+[submodule "extensions/DarkMode"]
+	path = extensions/DarkMode
+	url = https://github.com/wikimedia/mediawiki-extensions-DarkMode.git
+	branch = REL1_39

--- a/extensions/ArchLinux/ArchNavBar.php
+++ b/extensions/ArchLinux/ArchNavBar.php
@@ -10,7 +10,7 @@ namespace MediaWiki\Extensions\ArchLinux;
  * @var string $archNavBarSelectedDefault
  */
 ?>
-<div id="archnavbar" class="noprint">
+<div id="archnavbar" class="noprint mw-no-invert">
     <div id="archnavbarlogo">
         <p><a id="logo" href="<?= $archHome ?>"></a></p>
     </div>


### PR DESCRIPTION
Add DarkMode toggle. Intended to coincide with https://gitlab.archlinux.org/archlinux/infrastructure/-/merge_requests/664. The other PR for this is stale. My previous PR was automatically closed when I synced my fork. Please let me know if you see any issues, and I will change them right away.