### PR TITLE
Arch style fixes for MediaWiki 1.39 Vector 2022

### DIFF
--- a/extensions/ArchLinux/modules/skins/vector.less
+++ b/extensions/ArchLinux/modules/skins/vector.less
@@ -102,6 +102,12 @@ body.skin-vector-2022 {
   #mw-panel-toc {
     left: auto;
   }
+
+  // Restore language links which disappeared in the Vector 2022 version 1.39
+  #p-lang-btn.mw-portlet-empty {
+    display: block;
+    float: right;
+  }
 }
 
 // Vector legacy

--- a/extensions/ArchLinux/modules/skins/vector.less
+++ b/extensions/ArchLinux/modules/skins/vector.less
@@ -94,6 +94,14 @@ body.skin-vector-2022 {
   #p-personal.emptyPortlet {
     display: block;
   }
+
+  // Align the TOC button and menu
+  #vector-toc-collapsed-button {
+    margin-left: 0;
+  }
+  #mw-panel-toc {
+    left: auto;
+  }
 }
 
 // Vector legacy


### PR DESCRIPTION
* Align the "hidden" table of contents button and menu with the page content border
* Restore language links (move workaround from https://wiki.archlinux.org/title/MediaWiki:Common.css)

Before:
![Screenshot 2022-12-23 at 12-44-58 Pacman - LocalTestWiki](https://user-images.githubusercontent.com/17086862/209322613-009f6bb2-19de-4ba2-96a1-0676b5233835.png)

After:
![Screenshot 2022-12-23 at 12-45-39 Pacman - LocalTestWiki](https://user-images.githubusercontent.com/17086862/209322629-2f411a06-b03d-4817-9ae8-93f9223010c4.png)

(the screenshots are from a local test wiki, so ignore the article contents)

