### PR TITLE
Add Extension:NativeSvgHandler

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -30,3 +30,7 @@
 	path = extensions/DarkMode
 	url = https://github.com/wikimedia/mediawiki-extensions-DarkMode.git
 	branch = REL1_40
+[submodule "extensions/NativeSvgHandler"]
+	path = extensions/NativeSvgHandler
+	url = https://github.com/wikimedia/mediawiki-extensions-NativeSvgHandler.git
+	branch = REL1_40


### PR DESCRIPTION
This will allow MediaWiki to display SVG format images. See https://www.mediawiki.org/wiki/Manual:Image_administration#SVG

Discussion in https://wiki.archlinux.org/title/ArchWiki_talk:Maintenance_Team#Replace_PNG_images_with_SVG