### PR TITLE
Fix padding and alignment for Vector 2022 in MediaWiki 1.40

### DIFF
--- a/extensions/ArchLinux/modules/skins/vector.less
+++ b/extensions/ArchLinux/modules/skins/vector.less
@@ -84,9 +84,29 @@ body.skin-vector-2022 {
   }
 
   // keep padding as we are using a visual border
-  @media screen and (min-width: 1000px) {
+  @media screen {
     .mw-body {
-      padding-left: 0.5em;
+      padding: 1.5em;
+    }
+    .mw-ui-icon-flush-left {
+      margin-left: 0;
+    }
+    .mw-ui-icon-flush-right {
+      margin-right: 0;
+    }
+  }
+  @media screen and (max-width: 999px) {
+    // move horizontal padding from .mw-page-container to .mw-body and .mw-footer
+    .mw-page-container {
+      padding-left: 0;
+      padding-right: 0;
+    }
+    .mw-body, .mw-footer {
+      padding: 0.5em;
+    }
+    // increase max-width from 60em to 100%
+    .mw-content-container {
+      max-width: 100%;
     }
   }
 
@@ -107,6 +127,12 @@ body.skin-vector-2022 {
   #p-lang-btn.mw-portlet-empty {
     display: block;
     float: right;
+  }
+
+  // Align the language selector
+  .vector-page-titlebar > .mw-ui-button:last-child,
+  .vector-page-titlebar > .mw-portlet-lang:last-child {
+    margin-right: auto;
   }
 }
 


### PR DESCRIPTION
Remove left and right padding around `.mw-content-container` when the screen width is less than 1000px. "Small screens" need all the horizontal space they can get.

Align the header contents and language selector so that they do not extend too far and trigger horizontal scrolling.

If everything works as it should it should looks like this:

Before:
![Screenshot 2023-10-04 at 18-00-00 Installation guide - ArchWiki](https://github.com/archlinux/archwiki/assets/17086862/6ddbd4c8-543f-4e08-9150-0214a6ec2985)

After:
![Screenshot 2023-10-04 at 18-00-19 Installation guide - ArchWiki](https://github.com/archlinux/archwiki/assets/17086862/57b02b23-d861-47e3-8fa9-58dd181f401b)

/cc @lahwaacz  @christian-heusel
