### PR TITLE
Improve sidebar menus in Vector 2022

### DIFF
--- a/extensions/ArchLinux/modules/arch_common.less
+++ b/extensions/ArchLinux/modules/arch_common.less
@@ -101,6 +101,7 @@ body {
 /* Colors of links in the content, MediaWiki navigation and the footer */
 #content,
 header.mw-header li:not(.new), // Vector
+#mw-panel-toc,                // Vector
 #mw-navigation li:not(.new),  // Legacy Vector
 #mw-panel li:not(.new),       // Legacy Vector
 #column-one li:not(.new),     // MonoBook

--- a/extensions/ArchLinux/modules/skins/vector.less
+++ b/extensions/ArchLinux/modules/skins/vector.less
@@ -115,14 +115,6 @@ body.skin-vector-2022 {
     display: block;
   }
 
-  // Align the TOC button and menu
-  #vector-toc-collapsed-button {
-    margin-left: 0;
-  }
-  #mw-panel-toc {
-    left: auto;
-  }
-
   // Restore language links which disappeared in the Vector 2022 version 1.39
   #p-lang-btn.mw-portlet-empty {
     display: block;

--- a/extensions/ArchLinux/modules/skins/vector.less
+++ b/extensions/ArchLinux/modules/skins/vector.less
@@ -115,6 +115,34 @@ body.skin-vector-2022 {
     display: block;
   }
 
+  // Fix style and layout of main menu in the left sidebar
+  @media screen {
+    // NOTE: #vector-main-menu alone is not unique as of MW 1.40
+    #vector-main-menu.vector-main-menu {
+      background: @content-background-color;
+      border: @content-border-style;
+      width: auto;
+      margin-left: 0;
+      margin-top: 0;
+      margin-bottom: 1em;
+    }
+  }
+
+  // Fix layout of the TOC menu in the left sidebar
+  @media screen and (min-width: 1000px) {
+    // NOTE: #mw-panel-toc alone is not specific enough
+    #mw-panel-toc.mw-table-of-contents-container {
+      margin-left: 0;
+      #vector-toc-pinned-container {
+        margin-top: 0 !important;
+        border: @content-border-style;
+        .vector-toc, .vector-toc::after {
+          width: auto;
+        }
+      }
+    }
+  }
+
   // Restore language links which disappeared in the Vector 2022 version 1.39
   #p-lang-btn.mw-portlet-empty {
     display: block;


### PR DESCRIPTION
The first screenshot in https://github.com/archlinux/archwiki/pull/69#pullrequestreview-1657967184 shows that the left sidebar menus in Vector 2022 look weird: the TOC menu has wrong font color and white background but no border, and the main menu above it has actually slightly different background from the rest of the page.

After these changes, the menus look like this:

1. wide:
   ![Screen Shot 2023-10-06 at 19 58 29](https://github.com/archlinux/archwiki/assets/1289205/b0963df8-0058-4667-8279-beb50040680d)
2. medium:
    ![Screen Shot 2023-10-06 at 19 58 49](https://github.com/archlinux/archwiki/assets/1289205/21ab22f4-ea39-4020-a581-79bddb7ee889)
3. narrow:
    ![Screen Shot 2023-10-06 at 19 59 24](https://github.com/archlinux/archwiki/assets/1289205/6e226d6a-2c4c-4530-bc08-cf3cce622af6)

This extends https://github.com/archlinux/archwiki/pull/69, I will rebase when it is merged.

/cc @nl6720 @christian-heusel 