### PR TITLE
Timeless skin for Arch (take 2)

### DIFF
--- a/extensions/ArchLinux/extension.json
+++ b/extensions/ArchLinux/extension.json
@@ -30,6 +30,7 @@
         "arch_common.less"
       ],
       "skinStyles": {
+        "timeless": "skins/timeless.less",
         "vector": "skins/vector.less",
         "vector-2022": "skins/vector.less",
         "monobook": "skins/monobook.less"

--- a/extensions/ArchLinux/modules/skins/timeless.less
+++ b/extensions/ArchLinux/modules/skins/timeless.less
@@ -33,11 +33,6 @@ body, #mw-content-container {
     background: transparent;
 }
 
-/* z-order fix */
-#personal-inner {
-    z-index: 200;
-}
-
 /* integrate footer into page background */
 #mw-footer {
     padding-left: 16em;
@@ -101,6 +96,40 @@ body, #mw-content-container {
     }
     #mw-content {
         margin-top: 1.75em;
+    }
+    /* avoid relative and absolute positioning, set the layout using grid */
+    #mw-content-block {
+        position: unset;
+        display: grid;
+        grid-template-columns: auto 1fr;
+        grid-template-rows: auto;
+        /* content takes all columns on second row */
+        #mw-content-wrapper {
+            grid-row: 2;
+            grid-column-start: 1;
+            grid-column-end: -1;
+            /* remove margin that was for relative/absolute positioning */
+            #mw-content {
+                margin-top: 0;
+            }
+        }
+        /* Navigation, Wiki tools and Page tools take columns in the first row */
+        #mw-site-navigation, #mw-related-navigation {
+            grid-row: 1;
+            position: unset;
+            top: unset;
+            left: unset;
+            right: unset;
+        }
+        /* align navigation to the search box */
+        #mw-site-navigation {
+            margin-left: 2em;
+        }
+        /* Swap left and right margins since it is aligned to the left */
+        #mw-related-navigation > * {
+            margin-left: 0em;
+            margin-right: 1em;
+        }
     }
 }
 @media screen and (max-width:850px) {

--- a/extensions/ArchLinux/modules/skins/timeless.less
+++ b/extensions/ArchLinux/modules/skins/timeless.less
@@ -12,11 +12,12 @@
 /* make room for archnavbar and disable fixed searchbar */
 body, #mw-content-container {
     margin-top: 0;
-    background-color: @body-background-color;
 }
 #mw-content-container {
     border-bottom: none;
     padding-top: .5em;
+    background-color: @body-background-color;
+    background-image: none;
 }
 #mw-header-hack, #mw-header-nav-hack {
     display: none !important;

--- a/extensions/ArchLinux/modules/skins/timeless.less
+++ b/extensions/ArchLinux/modules/skins/timeless.less
@@ -4,6 +4,10 @@
 #p-logo {
     display: none !important;
 }
+/* hide logo text, but keep its box in the layout */
+#p-logo-text {
+    visibility: hidden;
+}
 
 /* make room for archnavbar and disable fixed searchbar */
 body, #mw-content-container {
@@ -89,6 +93,9 @@ body, #mw-content-container {
     }
 }
 @media screen and (min-width:851px) and (max-width:1099px) {
+    #p-logo-text {
+        display: none;
+    }
     #mw-footer {
         padding-left: 1em;
     }
@@ -97,10 +104,13 @@ body, #mw-content-container {
     }
 }
 @media screen and (max-width:850px) {
+    #p-logo-text {
+        display: none;
+    }
     #mw-footer {
         padding-left: 1em;
     }
-    #p-logo-text, #site-navigation h2, #site-tools h2, #user-tools h2 {
+    #site-navigation h2, #site-tools h2, #user-tools h2 {
         top: 75px;
     }
     .sidebar-inner, .dropdown {

--- a/extensions/ArchLinux/modules/skins/timeless.less
+++ b/extensions/ArchLinux/modules/skins/timeless.less
@@ -64,6 +64,23 @@ body, #mw-content-container {
     }
 }
 
+/* reset special border of the page title */
+.mw-body {
+    h1.firstHeading {
+        border-bottom: solid 3px #c8ccd1;
+    }
+}
+
+/* change MediaWiki's @blue color to Arch's blue */
+.suggestions {
+    .suggestions-result-current {
+        background-color: @link-color-normal;
+    }
+}
+.tools-inline li.selected {
+    border-bottom-color: @link-color-normal;
+}
+
 
 /* fixes for specific widths */
 @media screen and (max-width:1339px) {
@@ -91,5 +108,9 @@ body, #mw-content-container {
     }
     #menus-cover {
         top: 65px;
+    }
+    /* reset background for the box with category links (placed below the content) */
+    #mw-content-block {
+        background: @body-background-color;
     }
 }

--- a/extensions/ArchLinux/modules/skins/timeless.less
+++ b/extensions/ArchLinux/modules/skins/timeless.less
@@ -9,8 +9,13 @@
     visibility: hidden;
 }
 
+/* let body take the full height so its background applies in dark mode */
+body {
+    height: 100%;
+}
+
 /* make room for archnavbar and disable fixed searchbar */
-body, #mw-content-container {
+#mw-content-container {
     margin-top: 0;
 }
 #mw-content-container {

--- a/extensions/ArchLinux/modules/skins/timeless.less
+++ b/extensions/ArchLinux/modules/skins/timeless.less
@@ -1,0 +1,95 @@
+@import '../arch_definitions';
+
+/* disable default mediawiki logo  */
+#p-logo {
+    display: none !important;
+}
+
+/* make room for archnavbar and disable fixed searchbar */
+body, #mw-content-container {
+    margin-top: 0;
+    background-color: @body-background-color;
+}
+#mw-content-container {
+    border-bottom: none;
+    padding-top: .5em;
+}
+#mw-header-hack, #mw-header-nav-hack {
+    display: none !important;
+}
+#mw-header-container {
+    position: initial;
+    background: @body-background-color;
+}
+#mw-content {
+    border: @content-border-style;
+}
+#content {
+    border: none;
+    background: transparent;
+}
+
+/* z-order fix */
+#personal-inner {
+    z-index: 200;
+}
+
+/* integrate footer into page background */
+#mw-footer {
+    padding-left: 16em;
+    padding-right: 18em;
+}
+#mw-footer > * {
+    font-size: .8em;
+}
+.mw-footer-container {
+    border-top: none;
+    line-height: 1;
+    color: inherit;
+    box-shadow: none;
+}
+.mw-footer-container a, a {
+    color: @link-color-normal;
+    &:active {
+        color: @link-color-active;
+    }
+    &:hover {
+        color: @link-color-hover;
+    }
+    &:visited {
+        color: @link-color-visited;
+        &:hover {
+            color: @link-color-hover;
+        }
+    }
+}
+
+
+/* fixes for specific widths */
+@media screen and (max-width:1339px) {
+    #mw-footer {
+        padding-right: 1em;
+    }
+}
+@media screen and (min-width:851px) and (max-width:1099px) {
+    #mw-footer {
+        padding-left: 1em;
+    }
+    #mw-content {
+        margin-top: 1.75em;
+    }
+}
+@media screen and (max-width:850px) {
+    #mw-footer {
+        padding-left: 1em;
+    }
+    #p-logo-text, #site-navigation h2, #site-tools h2, #user-tools h2 {
+        top: 75px;
+    }
+    .sidebar-inner, .dropdown {
+        top: 7.75em;
+    }
+    #menus-cover {
+        top: 65px;
+    }
+}

--- a/extensions/ArchLinux/modules/skins/timeless.less
+++ b/extensions/ArchLinux/modules/skins/timeless.less
@@ -110,7 +110,7 @@ body, #mw-content-container {
     #mw-footer {
         padding-left: 1em;
     }
-    #site-navigation h2, #site-tools h2, #user-tools h2 {
+    #site-navigation h2, #site-tools h2, #user-tools h2, #personal-extra {
         top: 75px;
     }
     .sidebar-inner, .dropdown {

--- a/extensions/ArchLinux/modules/skins/timeless.less
+++ b/extensions/ArchLinux/modules/skins/timeless.less
@@ -86,6 +86,23 @@ body {
     border-bottom-color: @link-color-normal;
 }
 
+// reset hardcoded white-on-blue colors to black-on-gray as in Vector
+// (this affects e.g. the "Compare selected revisions" button on the history page)
+body.skin-timeless form:not( .oo-ui-layout ) {
+    button,
+    input[ type='submit' ] {
+        background-color: #f8f9fa;
+        color: #202122;
+        border-color: #a2a9b1;
+
+        &:not( :disabled ):hover,
+        &:not( :disabled ):active {
+            background-color: #ffffff;
+            color: #404244;
+        }
+    }
+}
+
 
 /* fixes for specific widths */
 @media screen and (max-width:1339px) {


### PR DESCRIPTION
This extends https://github.com/archlinux/archwiki/pull/50 with more tweaks for current MediaWiki 1.40. From my side it is finished, except for the inconsistencies in responsive behavior (see https://github.com/archlinux/archwiki/pull/50#issuecomment-1368253236) which I will try to address separately.

I believe that modifications for this skin will be easier to maintain than for the "new" Vector which breaks with every new major MediaWiki version. I think we can remove our modifications for Monobook though, which is old and ugly. Maybe we can even make Timeless the default.

This is what the Timeless skin looks like:

1. 1400 x 800
    ![Screen Shot 2023-10-06 at 22 28 18](https://github.com/archlinux/archwiki/assets/1289205/0d57e5ce-e2ad-4d7c-8a85-ae89fc5c0516)
2. 1100 x 800
    ![Screen Shot 2023-10-06 at 22 28 35](https://github.com/archlinux/archwiki/assets/1289205/87af46de-e07b-48b9-b0d7-3a0f00294fa1)
3. 1000 x 800
    ![Screen Shot 2023-10-06 at 22 28 43](https://github.com/archlinux/archwiki/assets/1289205/0858ff43-0449-49c0-a143-7faf3a33d733)
4. 800 x 800
    ![Screen Shot 2023-10-06 at 22 28 50](https://github.com/archlinux/archwiki/assets/1289205/3722efe9-5208-4e14-abc9-ea2510497a09)
5. 300 x 800
    ![Screen Shot 2023-10-06 at 22 29 13](https://github.com/archlinux/archwiki/assets/1289205/fc12ff0e-7550-4cce-88be-84b3cd6da6bf)

/cc @progandy @pierres @christian-heusel @nl6720 @AladW @kynikos