### PR TITLE
Draft: Fix blue colors

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -34,3 +34,6 @@
 	path = extensions/NativeSvgHandler
 	url = https://github.com/wikimedia/mediawiki-extensions-NativeSvgHandler.git
 	branch = REL1_40
+[submodule "extensions/ArchLinux/oojs-ui"]
+	path = extensions/ArchLinux/oojs-ui
+	url = https://github.com/lahwaacz/oojs-ui.git

--- a/extensions/ArchLinux/extension.json
+++ b/extensions/ArchLinux/extension.json
@@ -8,7 +8,8 @@
   "license-name": "GPL-2.0+",
   "type": "skin",
   "AutoloadClasses": {
-    "MediaWiki\\Extensions\\ArchLinux\\Hooks": "ArchLinux.hooks.php"
+    "MediaWiki\\Extensions\\ArchLinux\\Hooks": "ArchLinux.hooks.php",
+    "OOUI\\ArchLinuxTheme": "oojs-ui/php/themes/ArchLinuxTheme.php"
   },
   "Hooks": {
     "BeforePageDisplay": [
@@ -40,6 +41,21 @@
   "ResourceFileModulePaths": {
     "localBasePath": "modules",
     "remoteExtPath": "ArchLinux/modules"
+  },
+  "SkinOOUIThemes": {
+    "timeless": "ArchLinux",
+    "vector": "ArchLinux",
+    "vector-2022": "ArchLinux",
+    "monobook": "ArchLinux"
+  },
+  "OOUIThemePaths": {
+    "ArchLinux": {
+      "localBasePath": "oojs-ui/dist",
+      "remoteSkinPath": "ArchLinux/oojs-ui/dist",
+      "scripts": "oojs-ui-archlinux.js",
+      "styles": "oojs-ui-{module}-archlinux.css",
+      "images": "themes/archlinux/{module}.json"
+    }
   },
   "ConfigRegistry": {
     "archlinux": "GlobalVarConfig::newInstance"

--- a/extensions/ArchLinux/modules/arch_common.less
+++ b/extensions/ArchLinux/modules/arch_common.less
@@ -61,6 +61,18 @@ body {
         border-width: 0;
         border-radius: 0;
     }
+
+    // Color overrides for DiscussionTools
+    .ext-discussiontools-ui-replyWidget-modeTabs .ext-discussiontools-ui-modeTab.oo-ui-widget-disabled {
+        color: @link-color-normal;
+        box-shadow: inset 0 -2px 0 0 @link-color-normal;
+    }
+
+    // Color overrides for VisualEditor
+    .ve-ui-targetWidget-focused {
+        border-color: @link-color-normal;
+        box-shadow: inset 0 0 0 1px @link-color-normal;
+    }
 }
 
 /*

--- a/extensions/ArchLinux/modules/arch_common.less
+++ b/extensions/ArchLinux/modules/arch_common.less
@@ -73,6 +73,22 @@ body {
         border-color: @link-color-normal;
         box-shadow: inset 0 0 0 1px @link-color-normal;
     }
+
+    // Color overrides for deprecated "MW-UI" buttons (e.g. login form on Special:UserLogin)
+    .mw-ui-input:not(:disabled):focus {
+        border-color: @link-color-normal;
+        box-shadow: inset 0 0 0 1px @link-color-normal;
+    }
+    .mw-ui-button.mw-ui-progressive:not(.mw-ui-quiet):not(:disabled) {
+        &, &:active {
+            background-color: @link-color-normal;
+            border-color: @link-color-normal;
+        }
+        &:hover, &:active:hover {
+            background-color: transparent;
+            color: @link-color-hover;
+        }
+    }
 }
 
 /*

--- a/extensions/ArchLinux/modules/arch_common.less
+++ b/extensions/ArchLinux/modules/arch_common.less
@@ -98,36 +98,38 @@ body {
     font-weight: normal;
 }
 
-/* Colors of links in the content, MediaWiki navigation and the footer */
-#content,
-header.mw-header li:not(.new), // Vector
-#mw-panel-toc,                // Vector
-#mw-navigation li:not(.new),  // Legacy Vector
-#mw-panel li:not(.new),       // Legacy Vector
-#column-one li:not(.new),     // MonoBook
-#footer {
+// Colors of links in the content, footer and MediaWiki UI elements
+#globalWrapper,     // Monobook (contains all page elements except archnavbar)
+#mw-wrapper,        // Timeless (contains all page elements except archnavbar)
+.mw-page-container, // Vector (contains all page elements except archnavbar)
+.mw-body,           // Legacy Vector
+#mw-navigation,     // Legacy Vector
+.mw-footer          // Legacy Vector
+{
     a:not([role=button]) {
         .arch-link-color();
     }
 }
 
-/* Color of visited links for content and left column
- * (not for MediaWiki navigation elements above the page) */
+// Color of visited links for content, left sidebar and right sidebar
+// (not for MediaWiki UI elements and the footer)
 #content,
-#mw-panel li:not(.new),       // Legacy Vector
-#p-navigation li:not(.new),   // MonoBook
-#p-tb li:not(.new)            // MonoBook
+#p-navigation li:not(.new),         // MonoBook, Timeless
+#p-tb li:not(.new),                 // MonoBook, Timeless
+.vector-main-menu-container,        // Vector
+#mw-panel-toc,                      // Vector
+.vector-legacy-sidebar li:not(.new) // Legacy Vector
 {
-  a:not(.new):not([role=button]):visited {
-    color: @link-color-visited !important;
-  }
+    a:not(.new):visited {
+        color: @link-color-visited !important;
+    }
 }
 
-/* Color for links to inexistent pages */
+// Color for links to inexistent pages
 a.new,
 a.new:visited,
-#mw-navigation li.new a,         // Vector
-#mw-navigation li.new a:visited  // Vector
+#mw-navigation li.new a,         // tabs in Legacy Vector, Monotbook, Timeless
+#mw-navigation li.new a:visited  // tabs in Legacy Vector, Monotbook, Timeless
 {
     color: @link-color-new !important;
 }

--- a/extensions/ArchLinux/modules/arch_common.less
+++ b/extensions/ArchLinux/modules/arch_common.less
@@ -106,23 +106,9 @@ header.mw-header li:not(.new), // Vector
 #mw-panel li:not(.new),       // Legacy Vector
 #column-one li:not(.new),     // MonoBook
 #footer {
-  a:not([role=button]) {
-    &:not(.new) {
-      text-decoration: none;
-      color: @link-color-normal !important;
-      &:hover {
-        text-decoration: underline;
-        background-color: transparent;
-        color: @link-color-hover !important;
-      }
+    a:not([role=button]) {
+        .arch-link-color();
     }
-
-    &:active, &:focus,
-    /* a:hover overrides a:active, which we don't want' */
-    &:active:hover, &:focus:hover {
-      color: @link-color-active !important;
-    }
-  }
 }
 
 /* Color of visited links for content and left column

--- a/extensions/ArchLinux/modules/arch_definitions.less
+++ b/extensions/ArchLinux/modules/arch_definitions.less
@@ -15,7 +15,7 @@
 @toc-border-style: 1px solid #d7dfe3;
 @footer-text-color: #333;
 
-@link-color-normal: #07b;
+@link-color-normal: #08c;
 @link-color-hover: #999;
 @link-color-active: #e90;
 @link-color-visited: #666;

--- a/extensions/ArchLinux/modules/arch_definitions.less
+++ b/extensions/ArchLinux/modules/arch_definitions.less
@@ -20,3 +20,24 @@
 @link-color-active: #e90;
 @link-color-visited: #666;
 @link-color-new: #b00;
+
+// Mixin for styling links
+.arch-link-color() {
+    &:not(.new) {
+        text-decoration: none;
+        color: @link-color-normal !important;
+        &:hover {
+            text-decoration: underline;
+            background-color: transparent;
+            color: @link-color-hover !important;
+        }
+    }
+
+    &:active,
+    &:focus,
+    &:active:hover,  // a:hover overrides a:active, which we do not want
+    &:focus:hover  // a:hover overrides a:focus, which we do not want
+    {
+        color: @link-color-active !important;
+    }
+}

--- a/extensions/ArchLinux/modules/skins/vector.less
+++ b/extensions/ArchLinux/modules/skins/vector.less
@@ -154,6 +154,11 @@ body.skin-vector-2022 {
   .vector-page-titlebar > .mw-portlet-lang:last-child {
     margin-right: auto;
   }
+
+  // Some buttons in Vector that are not created with OOUI
+  button.vector-pinnable-header-toggle-button {
+    .arch-link-color();
+  }
 }
 
 // Vector legacy


### PR DESCRIPTION
This builds on #70 and fixes many other places where the default MediaWiki blue color (`#36c`) was used instead of the Arch blue (`#08c`). I also boldly switched `@link-color-normal` from `#07b` (also used on bbs, bugs, security and aur) to `#08c` which is used in all Arch navbars and in archweb as the main blue color (besides `#3ad` and `#1794D1`).

The main part is the introduction of a custom OOUI theme, which is in a very _proof-of-concept_ stage, especially its integration in the repo. The other commits are independent and I can split them to a separate pull request if this becomes a blocker.

I made several changes _timeless_ so we don't need more updates after enabling the Timeless skin.

Some screenshots for comparison:

1. after #70 (before the OOUI theme and other commits here):
    ![Screen Shot 2023-10-08 at 15 41 40](https://github.com/archlinux/archwiki/assets/1289205/c42e62d1-80f0-4427-8cbe-2c3dc645055a)
2. after all commits here:
    ![Screen Shot 2023-10-08 at 15 19 01](https://github.com/archlinux/archwiki/assets/1289205/0eac0dde-d8f0-48aa-91dc-fd5def2d9240)

The icon left of "Add topic" is still in `#36c`, but it seems to be hardcoded somewhere...