### PR TITLE
Remove Extension:NativeSvgHandler

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,32 +1,32 @@
 [submodule "extensions/CheckUser"]
 	path = extensions/CheckUser
 	url = https://github.com/wikimedia/mediawiki-extensions-CheckUser.git
-	branch = REL1_40
+	branch = REL1_41
 [submodule "extensions/TitleKey"]
 	path = extensions/TitleKey
 	url = https://github.com/wikimedia/mediawiki-extensions-TitleKey.git
-	branch = REL1_40
+	branch = REL1_41
 [submodule "extensions/BounceHandler"]
 	path = extensions/BounceHandler
 	url = https://github.com/wikimedia/mediawiki-extensions-BounceHandler.git
-	branch = REL1_40
+	branch = REL1_41
 [submodule "extensions/Lockdown"]
 	path = extensions/Lockdown
 	url = https://github.com/wikimedia/mediawiki-extensions-Lockdown.git
-	branch = REL1_40
+	branch = REL1_41
 [submodule "extensions/UserMerge"]
 	path = extensions/UserMerge
 	url = https://github.com/wikimedia/mediawiki-extensions-UserMerge.git
-	branch = REL1_40
+	branch = REL1_41
 [submodule "extensions/CodeMirror"]
 	path = extensions/CodeMirror
 	url = https://github.com/wikimedia/mediawiki-extensions-CodeMirror.git
-	branch = REL1_40
+	branch = REL1_41
 [submodule "extensions/FlarumAuth"]
 	path = extensions/FlarumAuth
 	url = https://github.com/archlinux-de/mediawiki-extensions-FlarumAuth.git
-	branch = REL1_40
+	branch = REL1_41
 [submodule "extensions/DarkMode"]
 	path = extensions/DarkMode
 	url = https://github.com/wikimedia/mediawiki-extensions-DarkMode.git
-	branch = REL1_40
+	branch = REL1_41

--- a/.gitmodules
+++ b/.gitmodules
@@ -30,7 +30,3 @@
 	path = extensions/DarkMode
 	url = https://github.com/wikimedia/mediawiki-extensions-DarkMode.git
 	branch = REL1_40
-[submodule "extensions/NativeSvgHandler"]
-	path = extensions/NativeSvgHandler
-	url = https://github.com/wikimedia/mediawiki-extensions-NativeSvgHandler.git
-	branch = REL1_40


### PR DESCRIPTION
MediaWiki 1.41 supports SVG rendering natively (though it is still
off by default), so there is no need for Extension:NativeSvgHandler
anymore.

See https://www.mediawiki.org/wiki/Manual:$wgSVGNativeRendering

Also update `.gitmodules`.