### PR TITLE
vector.less: use Arch's background color for the header

### DIFF
--- a/extensions/ArchLinux/modules/skins/vector.less
+++ b/extensions/ArchLinux/modules/skins/vector.less
@@ -77,6 +77,9 @@ body.skin-vector-2022 {
   .vector-sticky-header {
     background: @body-background-color;
   }
+  .vector-header-container {
+    background-color: @body-background-color;
+  }
 
   // Match the font used in page title
   .vector-sticky-header-context-bar-primary {


### PR DESCRIPTION
MediaWiki 1.41 changed the Vector 2022 skin's header, so its background color is now white. Fix it to use Arch's blue background.

See https://gitlab.archlinux.org/archlinux/infrastructure/-/merge_requests/784#note_151653 for details.